### PR TITLE
Relax http package requirements

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 dependencies:
   crypto: ^3.0.0
-  http: ^0.13.1
+  http: ">=0.13.5 <2.0.0"
   json_annotation: ^4.4.0
   meta: ^1.1.7
   logging: ^1.0.1


### PR DESCRIPTION
Relax the `http` package requirements to allow for the latest versions of `http`. All the changes to `http` are backwards compatible for `stripe-dart` package needs.

FYI @enyo - Please publish to pub.dev when you have a second.
