### PR TITLE
Adds useful fields to Subscription and CheckoutSession; fixes bug in CheckoutSession

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
         with:
-          sdk: 2.15.1
+          sdk: 3.0.0
 
       - name: Install dependencies
         run: dart pub get

--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -181,6 +181,7 @@ CheckoutSession _$CheckoutSessionFromJson(Map<String, dynamic> json) =>
       clientReferenceId: json['client_reference_id'] as String?,
       customer: json['customer'] as String?,
       paymentIntent: json['payment_intent'] as String?,
+      url: json['url'] as String?,
     );
 
 Map<String, dynamic> _$CheckoutSessionToJson(CheckoutSession instance) {
@@ -201,6 +202,7 @@ Map<String, dynamic> _$CheckoutSessionToJson(CheckoutSession instance) {
   val['payment_method_types'] = instance.paymentMethodTypes
       .map((e) => _$PaymentMethodTypeEnumMap[e]!)
       .toList();
+  writeNotNull('url', instance.url);
   return val;
 }
 

--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -181,6 +181,7 @@ CheckoutSession _$CheckoutSessionFromJson(Map<String, dynamic> json) =>
       clientReferenceId: json['client_reference_id'] as String?,
       customer: json['customer'] as String?,
       paymentIntent: json['payment_intent'] as String?,
+      status: json['status'] as String?,
       url: json['url'] as String?,
     );
 
@@ -202,6 +203,7 @@ Map<String, dynamic> _$CheckoutSessionToJson(CheckoutSession instance) {
   val['payment_method_types'] = instance.paymentMethodTypes
       .map((e) => _$PaymentMethodTypeEnumMap[e]!)
       .toList();
+  writeNotNull('status', instance.status);
   writeNotNull('url', instance.url);
   return val;
 }

--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -1895,6 +1895,11 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) {
         const TimestampConverter().toJson(instance.currentPeriodStart),
     'current_period_end':
         const TimestampConverter().toJson(instance.currentPeriodEnd),
+    'cancel_at_period_end': instance.cancelAtPeriodEnd,
+    'status': _$SubscriptionStatusEnumMap[instance.status]!,
+    'items': instance.items.toJson(
+      (value) => value.toJson(),
+    ),
     'start_date': const TimestampConverter().toJson(instance.startDate),
     'billing_cycle_anchor':
         const TimestampConverter().toJson(instance.billingCycleAnchor),

--- a/lib/src/messages/checkout_session.dart
+++ b/lib/src/messages/checkout_session.dart
@@ -55,16 +55,15 @@ class CheckoutSession extends Message {
   final String? status;
   final String? url;
 
-  CheckoutSession({
-    required this.object,
-    required this.id,
-    required this.paymentMethodTypes,
-    this.clientReferenceId,
-    this.customer,
-    this.paymentIntent,
-    this.status,
-    this.url
-  });
+  CheckoutSession(
+      {required this.object,
+      required this.id,
+      required this.paymentMethodTypes,
+      this.clientReferenceId,
+      this.customer,
+      this.paymentIntent,
+      this.status,
+      this.url});
 
   factory CheckoutSession.fromJson(Map<String, dynamic> json) =>
       _$CheckoutSessionFromJson(json);

--- a/lib/src/messages/checkout_session.dart
+++ b/lib/src/messages/checkout_session.dart
@@ -52,6 +52,7 @@ class CheckoutSession extends Message {
   final String? customer;
   final String? paymentIntent;
   final List<PaymentMethodType> paymentMethodTypes;
+  final String? url;
 
   CheckoutSession({
     required this.object,
@@ -60,6 +61,7 @@ class CheckoutSession extends Message {
     this.clientReferenceId,
     this.customer,
     this.paymentIntent,
+    this.url
   });
 
   factory CheckoutSession.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/messages/checkout_session.dart
+++ b/lib/src/messages/checkout_session.dart
@@ -55,15 +55,16 @@ class CheckoutSession extends Message {
   final String? status;
   final String? url;
 
-  CheckoutSession(
-      {required this.object,
-      required this.id,
-      required this.paymentMethodTypes,
-      this.clientReferenceId,
-      this.customer,
-      this.paymentIntent,
-      this.status,
-      this.url});
+  CheckoutSession({
+    required this.object,
+    required this.id,
+    required this.paymentMethodTypes,
+    this.clientReferenceId,
+    this.customer,
+    this.paymentIntent,
+    this.status,
+    this.url,
+  });
 
   factory CheckoutSession.fromJson(Map<String, dynamic> json) =>
       _$CheckoutSessionFromJson(json);

--- a/lib/src/messages/checkout_session.dart
+++ b/lib/src/messages/checkout_session.dart
@@ -52,6 +52,7 @@ class CheckoutSession extends Message {
   final String? customer;
   final String? paymentIntent;
   final List<PaymentMethodType> paymentMethodTypes;
+  final String? status;
   final String? url;
 
   CheckoutSession({
@@ -61,6 +62,7 @@ class CheckoutSession extends Message {
     this.clientReferenceId,
     this.customer,
     this.paymentIntent,
+    this.status,
     this.url
   });
 

--- a/lib/src/messages/event.dart
+++ b/lib/src/messages/event.dart
@@ -38,7 +38,7 @@ abstract class Event<T extends Message> extends Message {
       //   return BalanceTransactionEvent.fromJson(json) as T;
       case 'charge':
         return ChargeEvent.fromJson(json) as T;
-      case 'checkout_session':
+      case 'checkout.session':
         return CheckoutSessionEvent.fromJson(json) as T;
       case 'customer':
         return CustomerEvent.fromJson(json) as T;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
   sdk: ^3.0.0
 dependencies:
   crypto: ^3.0.0
-  http: ^0.13.1
   json_annotation: ^4.9.0
   meta: ^1.1.7
   logging: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A simple Stripe API wrapper, that is meant to be used on the server
 homepage: https://github.com/enyo/stripe-dart
 documentation: https://github.com/enyo/stripe-dart/blob/main/README.md
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^3.0.0
 dependencies:
   crypto: ^3.0.0
   http: ^0.13.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,8 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 dependencies:
   crypto: ^3.0.0
-  json_annotation: ^4.4.0
+  http: ^0.13.1
+  json_annotation: ^4.9.0
   meta: ^1.1.7
   logging: ^1.0.1
   dio: ^5.1.2


### PR DESCRIPTION
I needed access to a few more fields, so this small change adds:
* to class `Subscription`: `bool cancelAtPeriodEnd`
* to class `CheckoutSession`: `String? status`, `String? url` (the checkout URL)

And fixes an issue where decoding a `CheckoutSession` from JSON was using key `checkout_session` whereas the actual key is `checkout.session`.

I think these would be useful additions to your very useful package. Let me know if you have any questions.